### PR TITLE
Denormalize matchingText in text and termSearch endpoints

### DIFF
--- a/src/helpers/mapTextResult.ts
+++ b/src/helpers/mapTextResult.ts
@@ -1,0 +1,25 @@
+export const mapTextResult = (
+  parallelTextQueryResultRow: ParallelTextQueryResultRow,
+): DisambiguatedTextResult => {
+  const { parallelId, moduleId, rid, text } = parallelTextQueryResultRow;
+  try {
+    const maybeWordArray = JSON.parse(text);
+    if (Array.isArray(maybeWordArray)) {
+      return {
+        parallelId,
+        moduleId,
+        rid,
+        type: "wordArray",
+        wordArray: maybeWordArray,
+        html: "",
+      };
+    }
+  } catch (e) {
+    // Ignore this path.
+
+    // We can't return here because we need to handle the text being
+    // HTML but JSON.parse also succeeding (so the output is not the
+    // expected array), e.g. if the text is surrounded in quotes.
+  }
+  return { parallelId, moduleId, rid, type: "html", wordArray: [], html: text };
+};

--- a/src/routes/termSearch.ts
+++ b/src/routes/termSearch.ts
@@ -3,19 +3,26 @@ import { getVersificationSchemaIdFromModuleId } from "../helpers/moduleInfo.ts";
 import { getTermSearchQuery } from "../helpers/termSearchQueryBuilder.ts";
 import { getTextQuery } from "../helpers/parallelTextQueryBuilder.ts";
 import { getWordQuery } from "../helpers/wordMapQueryBuilder.ts";
+import { mapTextResult } from "../helpers/mapTextResult.ts";
 
-const mapMatchingTextSearchResults = (
+type MapToTermSearchResponseFunction = (
+  orderedResults: number[][],
+  matchingText: ParallelTextQueryResult,
+  moduleIds: number[],
+) => TermSearchTextResponse;
+const mapMatchingTextSearchResults: MapToTermSearchResponseFunction = (
   orderedResults,
   matchingText,
   moduleIds,
 ) =>
   orderedResults.map((parallelIds) =>
     moduleIds.map((moduleId) =>
-      parallelIds.map((parallelId) =>
-        matchingText.find((row) =>
+      parallelIds.map((parallelId) => {
+        const row = matchingText.find((row) =>
           row.parallelId === parallelId && row.moduleId === moduleId
-        )
-      )
+        );
+        return row ? mapTextResult(row) : null;
+      })
     )
   );
 

--- a/src/routes/termSearch.ts
+++ b/src/routes/termSearch.ts
@@ -4,6 +4,21 @@ import { getTermSearchQuery } from "../helpers/termSearchQueryBuilder.ts";
 import { getTextQuery } from "../helpers/parallelTextQueryBuilder.ts";
 import { getWordQuery } from "../helpers/wordMapQueryBuilder.ts";
 
+const mapMatchingTextSearchResults = (
+  orderedResults,
+  matchingText,
+  moduleIds,
+) =>
+  orderedResults.map((parallelIds) =>
+    moduleIds.map((moduleId) =>
+      parallelIds.map((parallelId) =>
+        matchingText.find((row) =>
+          row.parallelId === parallelId && row.moduleId === moduleId
+        )
+      )
+    )
+  );
+
 type ModuleWarmWords = {
   moduleId: number;
   wids: number[];
@@ -57,7 +72,6 @@ const get = ({
         if (data.length === 0) {
           return mainResolve({
             count,
-            orderedResults: [[]],
             matchingText: [],
             matchingWords: [],
             warmWords: [],
@@ -122,8 +136,11 @@ const get = ({
         ]) => {
           mainResolve({
             count,
-            orderedResults,
-            matchingText,
+            matchingText: mapMatchingTextSearchResults(
+              orderedResults,
+              matchingText,
+              moduleIds,
+            ),
             matchingWords,
             warmWords,
           });

--- a/src/routes/text.ts
+++ b/src/routes/text.ts
@@ -6,6 +6,18 @@ import {
   getModuleIdsFromModules,
   getVersificationSchemaIdFromModuleId,
 } from "../helpers/moduleInfo.ts";
+import { mapTextResult } from "../helpers/mapTextResult.ts";
+
+const getMatchingTextForModuleAndRow = (
+  moduleId: number,
+  parallelId: number,
+  matchingTextResult: ParallelTextQueryResult,
+) => {
+  const matchingText = matchingTextResult.find(
+    (row) => row.moduleId === moduleId && row.parallelId === parallelId,
+  );
+  return matchingText ? mapTextResult(matchingText) : null;
+};
 
 type Params = {
   modules: string;
@@ -46,10 +58,17 @@ const get = ({ reference, modules }: Params) =>
       matchingText: ParallelTextQueryResult,
       order: ParallelOrderingResult,
     ]) => {
-      mainResolve({
-        matchingText,
-        order: order.map((row) => row.parallelId),
-      });
+      mainResolve(
+        order.map((row) =>
+          moduleIds.map((moduleId) =>
+            getMatchingTextForModuleAndRow(
+              moduleId,
+              row.parallelId,
+              matchingText,
+            )
+          )
+        ),
+      );
     }).catch((error) => {
       console.error("Error while gathering words and paralel text");
       console.error(error);

--- a/types.d.ts
+++ b/types.d.ts
@@ -27,9 +27,10 @@ type WordResponse = {
 		value: string
 	}[]
 }
+
 type TermSearchResponse = {
 	count: number
-	matchingText: DisambiguatedTextResult[][]
+	matchingText: TermSearchTextResponse
 	matchingWords: {
 		wid: number
 		moduleId: number
@@ -46,7 +47,6 @@ type HighlightResponse = {
 		wid: number
 	}[]
 }
-type TextResponse = (DisambiguatedTextResult | null)[][]
 type DisambiguatedTextResult = {
 	parallelId: number
 	moduleId: number
@@ -55,6 +55,8 @@ type DisambiguatedTextResult = {
 	wordArray: WordArray
 	html: string
 }
+type TextResponse = (DisambiguatedTextResult | null)[][]
+type TermSearchTextResponse = (DisambiguatedTextResult | null)[][][]
 
 type WordArray = {
 	wid: number

--- a/types.d.ts
+++ b/types.d.ts
@@ -29,13 +29,7 @@ type WordResponse = {
 }
 type TermSearchResponse = {
 	count: number
-	orderedResults: number[][]
-	matchingText: {
-		parallelId: number
-		moduleId: number
-		rid: number
-		text: string
-	}[],
+	matchingText: DisambiguatedTextResult[][]
 	matchingWords: {
 		wid: number
 		moduleId: number
@@ -52,10 +46,22 @@ type HighlightResponse = {
 		wid: number
 	}[]
 }
-type TextResponse = {
-	matchingText: ParallelTextQueryResult,
-	order: number[]
+type TextResponse = (DisambiguatedTextResult | null)[][]
+type DisambiguatedTextResult = {
+	parallelId: number
+	moduleId: number
+	rid: number
+	type: "wordArray" | "html"
+	wordArray: WordArray
+	html: string
 }
+
+type WordArray = {
+	wid: number
+	leader?: string
+	text: string
+	trailer?: string
+}[]
 
 type ClickhouseResponse<T> = {
 	data: T
@@ -79,12 +85,13 @@ type WordQueryResult = {
 type ParallelOrderingResult = {
 	parallelId: number
 }[]
-type ParallelTextQueryResult = {
+type ParallelTextQueryResultRow = {
 	parallelId: number
 	moduleId: number
 	rid: number
 	text: string
-}[]
+}
+type ParallelTextQueryResult = ParallelTextQueryResultRow[]
 type TermSearchQueryResult = {
 	moduleId?: number
 	lowestParallelId: number


### PR DESCRIPTION
This PR simplifies the API by removing the `orderedResults` field. Previously, the client would need to map `matchingText` onto `orderedResults`. But the server now does this for the client.

This has a couple of implications:
1. When search results have duplicated verses, they are returned in duplicate.
2. When modules are completely absent in the results, they will still be represented in empty columns of the array of results.

We need to update docs and client to reflect these changes.