### PR TITLE
Integrate temp into search results

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -31,14 +31,6 @@ type WordResponse = {
 type TermSearchResponse = {
 	count: number
 	matchingText: TermSearchTextResponse
-	matchingWords: {
-		wid: number
-		moduleId: number
-	}[]
-	warmWords: {
-		wids: number[]
-		moduleId: number
-	}[]
 }
 type HighlightResponse = {
 	data: {
@@ -63,6 +55,7 @@ type WordArray = {
 	leader?: string
 	text: string
 	trailer?: string
+	temp?: string
 }[]
 
 type ClickhouseResponse<T> = {


### PR DESCRIPTION
This changes the termSearch api considerably, but again moves effort off the client and onto the server (not very significant). It simplifies things for the most part, but now there is an additional optional `temp` value on words in the `wordArray`. It can be "hot" or "warm" (or "").